### PR TITLE
Increase movecount condition based on PV node in LMR

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -205,7 +205,7 @@ namespace jet {
 
                 bool do_fullsearch = !isPvNode || movecount > 1;
 
-                if (!inCheck && isQuiet && movecount > 4 && depth >= 3) {
+                if (!inCheck && isQuiet && movecount > 2 && depth >= 3) {
                     Depth reduction = LmrTable[std::min(63, depth)][std::min(63, movecount)];
 
                     reduction += !isPvNode;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -205,7 +205,7 @@ namespace jet {
 
                 bool do_fullsearch = !isPvNode || movecount > 1;
 
-                if (!inCheck && isQuiet && movecount > 2 && depth >= 3) {
+                if (!inCheck && isQuiet && movecount > 2 + 2 * isPvNode && depth >= 3) {
                     Depth reduction = LmrTable[std::min(63, depth)][std::min(63, movecount)];
 
                     reduction += !isPvNode;


### PR DESCRIPTION
Elo   | 9.36 +- 5.62 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 3.00 (-2.94, 2.94) [0.00, 5.00]
Games | N: 5048 W: 938 L: 802 D: 3308
Penta | [41, 526, 1279, 612, 66]
https://rafiddev.pythonanywhere.com/test/65/