### PR TITLE
History malus

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -182,6 +182,8 @@ namespace jet {
             MoveGen::legalmoves<MoveGenType::ALL>(board, movelist);
             MoveOrdering::all(movelist, st, ss, entry.move());
 
+            Movelist quietlist;
+
             Move bestmove  = Move::none();
             int  movecount = 0;
 
@@ -196,6 +198,10 @@ namespace jet {
                 ss->move      = move;
                 st.nodes++;
                 movecount++;
+
+                if (isQuiet) {
+                    quietlist.add(move);
+                }
 
                 if constexpr (nt == NodeType::ROOT) {
                     if (movecount == 1 && depth == 1) {
@@ -248,13 +254,18 @@ namespace jet {
 
                         if (score >= beta) {
                             if (isQuiet) {
-                                MoveOrdering::updateHistory(st, move, depth);
                                 ss->updateKiller(move);
                             }
 
                             break;
                         }
                     }
+                }
+            }
+
+            if (alpha != oldAlpha) {
+                if (bestscore >= beta && board.isQuiet(bestmove)) {
+                    MoveOrdering::updateHistory(st, quietlist, bestmove, depth);
                 }
             }
 

--- a/src/search/history.hpp
+++ b/src/search/history.hpp
@@ -12,7 +12,7 @@ namespace jet {
             std::array<std::array<int16_t, 12>, 64> m_table;
 
         public:
-            static constexpr inline int16_t MAX_HISTORY = 8192;
+            static constexpr inline int16_t MAX_HISTORY = 2 << 13;
 
             auto& index(const chess::Board& board, const chess::Move& move) {
                 const auto piece = board.at(move.from());

--- a/src/search/history.hpp
+++ b/src/search/history.hpp
@@ -29,7 +29,7 @@ namespace jet {
             }
 
             static auto bonus(int depth) {
-                return depth * depth;
+                return 32 * depth;
             }
 
             void update(const chess::Board& board, const chess::Move& move, int bonus) {

--- a/src/search/moveorder.hpp
+++ b/src/search/moveorder.hpp
@@ -29,8 +29,14 @@ namespace jet {
             static constexpr inline int KILLER_1_SCORE = 80000;
             static constexpr inline int KILLER_2_SCORE = 70000;
 
-            static void updateHistory(SearchThread& st, const chess::Move& move, int depth) {
+            static void updateHistory(SearchThread& st, chess::Movelist& quiets, const chess::Move& move, int depth) {
                 st.history.update(st.board(), move, History::bonus(depth));
+
+                for (auto& quiet : quiets) {
+                    if (quiet != move) {
+                        st.history.update(st.board(), quiet, -History::bonus(depth));
+                    }
+                }
             }
 
             static void captures(const chess::Board& board, chess::Movelist& movelist) {


### PR DESCRIPTION
Elo   | 5.33 +- 4.02 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 10166 W: 1885 L: 1729 D: 6552
Penta | [101, 1093, 2552, 1223, 114]
https://rafiddev.pythonanywhere.com/test/85/