### PR TITLE
Late move pruning

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -187,11 +187,21 @@ namespace jet {
             Move bestmove  = Move::none();
             int  movecount = 0;
 
+            bool hasNonPawnMat = board.hasNonPawnMat();
+
             for (int i = 0; i < movelist.size(); i++) {
                 movelist.nextmove(i);
 
                 const auto& move    = movelist[i];
                 const bool  isQuiet = board.isQuiet(move);
+
+                if constexpr (nt != NodeType::ROOT) {
+                    if (isQuiet && bestscore > -constants::IS_MATE && hasNonPawnMat) {
+                        if (!inCheck && !isPvNode && depth <= 7 && quietlist.size() >= (4 + depth * 4)) {
+                            break;
+                        }
+                    }
+                }
 
                 st.makeMove<true>(move);
                 (ss + 1)->ply = ss->ply + 1;


### PR DESCRIPTION
Elo   | 25.09 +- 9.80 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 1720 W: 369 L: 245 D: 1106
Penta | [14, 144, 435, 238, 29]
https://rafiddev.pythonanywhere.com/test/86/