### PR TITLE
SEE + MVVLVA move ordering

### DIFF
--- a/src/search/moveorder.hpp
+++ b/src/search/moveorder.hpp
@@ -71,7 +71,7 @@ namespace jet {
                     if (move == ttMove) {
                         move.setScore(TT_MOVE_SCORE);
                     } else if (target != PieceType::NONE) {
-                        move.setScore(SEE_SCORE + _mvvlva(target, attacker));
+                        move.setScore(see(board, move, 0) * SEE_SCORE + _mvvlva(target, attacker));
                     } else if (move == ss->killers[0]) {
                         move.setScore(KILLER_1_SCORE);
                     } else if (move == ss->killers[1]) {


### PR DESCRIPTION
Elo   | 10.19 +- 5.89 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.99 (-2.94, 2.94) [0.00, 5.00]
Games | N: 4572 W: 850 L: 716 D: 3006
Penta | [40, 462, 1167, 558, 59]
https://rafiddev.pythonanywhere.com/test/89/