### PR TITLE
Decrease reduction in LMR for good noisy moves

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -221,8 +221,12 @@ namespace jet {
 
                 bool do_fullsearch = !isPvNode || movecount > 1;
 
-                if (!inCheck && isQuiet && movecount > 2 + 2 * isPvNode && depth >= 3) {
+                if (!inCheck && movecount > 2 + 2 * isPvNode && depth >= 3) {
                     Depth reduction = LmrTable[std::min(63, depth)][std::min(63, movecount)];
+
+                    if (!isQuiet) {
+                        reduction -= MoveOrdering::see(board, move, -100 * depth);
+                    }
 
                     reduction += !isPvNode;
                     reduction += !improving;
@@ -231,7 +235,7 @@ namespace jet {
 
                     score = -negamax<NodeType::NONPV>(-alpha - 1, -alpha, depth - reduction, st, ss + 1);
 
-                    do_fullsearch = score > alpha;
+                    do_fullsearch = score > alpha && reduction;
                 }
 
                 if (do_fullsearch) {


### PR DESCRIPTION
Elo   | 5.09 +- 3.87 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 10854 W: 1990 L: 1831 D: 7033
Penta | [107, 1174, 2738, 1269, 139]
https://rafiddev.pythonanywhere.com/test/90/