### PR TITLE
Adjust SEE threshold in qsearch for ordering

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -50,7 +50,7 @@ namespace jet {
             Board&   board = st.board();
             Movelist movelist;
             MoveGen::legalmoves<MoveGenType::CAPTURE>(board, movelist);
-            MoveOrdering::capturesWithSee(board, movelist);
+            MoveOrdering::capturesWithSee(board, movelist, -100);
 
             Value score = -constants::VALUE_INFINITY;
 

--- a/src/search/moveorder.hpp
+++ b/src/search/moveorder.hpp
@@ -50,13 +50,13 @@ namespace jet {
                 }
             }
 
-            static void capturesWithSee(const chess::Board& board, chess::Movelist& movelist) {
+            static void capturesWithSee(const chess::Board& board, chess::Movelist& movelist, int threshold = 0) {
                 for (auto& move : movelist) {
                     const auto attacker = board.pieceTypeAt(move.from());
                     const auto target   = board.pieceTypeAt(move.to());
 
                     if (target != PieceType::NONE) {
-                        move.setScore(see(board, move, 0) * SEE_SCORE + _mvvlva(target, attacker));
+                        move.setScore(see(board, move, threshold) * SEE_SCORE + _mvvlva(target, attacker));
                     }
                 }
             }


### PR DESCRIPTION
Elo   | 9.09 +- 5.68 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.99 (-2.94, 2.94) [0.00, 5.00]
Games | N: 5354 W: 1070 L: 930 D: 3354
Penta | [53, 569, 1304, 687, 64]
https://rafiddev.pythonanywhere.com/test/119/