### PR TITLE
Introducing hexadecane_512_v1 net

### DIFF
--- a/makefile
+++ b/makefile
@@ -3,7 +3,7 @@ CXX := clang++-17
 ARCH := -march=native
 CXXFLAGS := -std=c++20 -flto $(ARCH) -fexceptions -Wall -Wextra
 LDFLAGS :=
-EVALFILE := src/epoch_370.net
+EVALFILE := src/latest.net
 
 CXXFLAGS += -DNNFILE=\"$(EVALFILE)\"
 

--- a/makefile
+++ b/makefile
@@ -3,7 +3,7 @@ CXX := clang++-17
 ARCH := -march=native
 CXXFLAGS := -std=c++20 -flto $(ARCH) -fexceptions -Wall -Wextra
 LDFLAGS :=
-EVALFILE := src/net16_512_epoch_310.net
+EVALFILE := src/epoch_370.net
 
 CXXFLAGS += -DNNFILE=\"$(EVALFILE)\"
 

--- a/makefile
+++ b/makefile
@@ -3,7 +3,7 @@ CXX := clang++-17
 ARCH := -march=native
 CXXFLAGS := -std=c++20 -flto $(ARCH) -fexceptions -Wall -Wextra
 LDFLAGS :=
-EVALFILE := src/latest.net
+EVALFILE := src/hexadecane_512_v1.net
 
 CXXFLAGS += -DNNFILE=\"$(EVALFILE)\"
 


### PR DESCRIPTION
#### What's New?
- Implemented training with bestmove capture positions where SEE < 0, aligning with Stockfish's latest training procedures ([details](https://github.com/official-stockfish/Stockfish/pull/5090)).
  
#### Network Architecture (the usual as before):
-  `(12288->512)->1`.
- 16 king buckets, horizontally mirrored.

Check out the latest performance metrics [here](https://rafiddev.pythonanywhere.com/test/248/).