### PR TITLE
Update net to hexadecane_512_v1

### DIFF
--- a/makefile
+++ b/makefile
@@ -3,7 +3,7 @@ CXX := clang++-17
 ARCH := -march=native
 CXXFLAGS := -std=c++20 -flto $(ARCH) -fexceptions -Wall -Wextra
 LDFLAGS :=
-EVALFILE := src/hexadecane_512_v1.net
+EVALFILE := src/hexadecane_512_v2.net
 
 CXXFLAGS += -DNNFILE=\"$(EVALFILE)\"
 


### PR DESCRIPTION
#### Network Architecture (the usual as before):
-  `(12288->512)->1`.
- 16 king buckets, horizontally mirrored.

Check out the latest performance metrics [here](https://rafiddev.pythonanywhere.com/test/253/).